### PR TITLE
Fix Dockerfile CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ WORKDIR /code
 COPY package.json /code/package.json
 RUN npm install
 
-CMD ["/code/bin/init"]
+CMD ["/code/bin/run"]


### PR DESCRIPTION
This fixes regression from 08663e1713fa78e525551b451ec65feca75edeab

However when running inside Docker for Mac, I'm still unable to get it to work properly :(. `docker-compose logs` shows that homebridge starts up properly: `homebridge_1  | [5/2/2017, 7:26:43 PM] Homebridge is running on port 51826.` but iOS Home shows No Response. This problem still occurs if I disable my macOS Firewall. Homebridge works fine on my network when running outside of Docker. Let me know if you have any ideas. 